### PR TITLE
feat: Add Firestore Security Rules (Server Task 2)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -17,8 +17,8 @@ service cloud.firestore {
     
     // Users collection
     match /users/{uid} {
-      // Public read if user is not deleted
-      allow read: if resource.data.isDeleted != true;
+      // Public read if user is not deleted (must be authenticated)
+      allow read: if isAuthenticated() && resource.data.isDeleted != true;
       
       // Owner can write their own profile
       allow write: if isOwner(uid);


### PR DESCRIPTION
## Task 2: Firestore Security Rules

Implements security rules for all Firestore collections as specified in server_tasks.md.

### Changes
- Created `firestore.rules` with access control for:
  - **users** collection: Public read if not deleted, owner write
  - **ticks** sub-collection: Public read if parent user is public, owner write
  - **trips** collection: Read if userIsPublic=true, owner write
  - **connections** collection: Create by requester, update by receiver, read/delete by both parties

### Security Features
- Authentication checks via helper functions
- Soft delete support for user profiles
- Privacy-aware access to user ticks
- Denormalized userIsPublic field for efficient trip queries
- Connection request authorization logic

### Testing
Deploy to Firebase console and test with Firestore emulator or production environment.

Closes Server Task #2