### PR TITLE
feat: Add Firestore Composite Indexes (Server Task 3)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,37 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "trips",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "location.areaId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "gradeRange.min",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "trips",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userIsPublic",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "location.areaId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "gradeRange.min",
+          "order": "ASCENDING"
+        }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}


### PR DESCRIPTION
## Task 3: Firestore Indexes

Implements composite indexes to enable complex queries for Partner Discovery feature.

### Changes
- Created `firestore.indexes.json` with two composite indexes:
  1. **Basic Partner Discovery**: `location.areaId` + `gradeRange.min`
  2. **Public Trips Filter**: `userIsPublic` + `location.areaId` + `gradeRange.min`

### Query Support
These indexes enable efficient queries like:
```javascript
db.collection('trips')
  .where('userIsPublic', '==', true)
  .where('location.areaId', '==', targetAreaId)
  .where('gradeRange.min', '>=', minGrade)
```

Client can then filter results by date range locally to find matching climbing partners.

### Deployment
Deploy with: `firebase deploy --only firestore:indexes`

Closes Server Task #3