### PR TITLE
feat: Route Search Local Repository with Hive caching (Issue #8)

### DIFF
--- a/lib/core/data/adapters/cached_routes_adapter.dart
+++ b/lib/core/data/adapters/cached_routes_adapter.dart
@@ -1,0 +1,39 @@
+import 'package:hive/hive.dart';
+import 'package:rockmate/core/data/models/cached_routes.dart';
+import 'package:rockmate/core/domain/entities/route_entity.dart';
+import 'package:rockmate/core/data/adapters/route_entity_adapter.dart';
+
+class CachedRoutesAdapter extends TypeAdapter<CachedRoutes> {
+  @override
+  final int typeId = 1;
+
+  @override
+  CachedRoutes read(BinaryReader reader) {
+    final routesLength = reader.readInt();
+    final routes = <RouteEntity>[];
+    final routeAdapter = RouteEntityAdapter();
+    
+    for (int i = 0; i < routesLength; i++) {
+      routes.add(routeAdapter.read(reader));
+    }
+    
+    final timestamp = reader.readInt();
+    
+    return CachedRoutes(
+      routes: routes,
+      timestamp: timestamp,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, CachedRoutes obj) {
+    writer.writeInt(obj.routes.length);
+    final routeAdapter = RouteEntityAdapter();
+    
+    for (final route in obj.routes) {
+      routeAdapter.write(writer, route);
+    }
+    
+    writer.writeInt(obj.timestamp);
+  }
+}

--- a/lib/core/data/adapters/route_entity_adapter.dart
+++ b/lib/core/data/adapters/route_entity_adapter.dart
@@ -1,0 +1,31 @@
+import 'package:hive/hive.dart';
+import 'package:rockmate/core/domain/entities/route_entity.dart';
+
+class RouteEntityAdapter extends TypeAdapter<RouteEntity> {
+  @override
+  final int typeId = 0;
+
+  @override
+  RouteEntity read(BinaryReader reader) {
+    return RouteEntity(
+      id: reader.readString(),
+      name: reader.readString(),
+      grade: reader.readString(),
+      type: reader.readString(),
+      rating: reader.readDouble(),
+      location: reader.readString(),
+      imageUrl: reader.readString(),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, RouteEntity obj) {
+    writer.writeString(obj.id);
+    writer.writeString(obj.name);
+    writer.writeString(obj.grade);
+    writer.writeString(obj.type);
+    writer.writeDouble(obj.rating);
+    writer.writeString(obj.location);
+    writer.writeString(obj.imageUrl ?? '');
+  }
+}

--- a/lib/core/data/models/cached_routes.dart
+++ b/lib/core/data/models/cached_routes.dart
@@ -1,0 +1,17 @@
+import 'package:rockmate/core/domain/entities/route_entity.dart';
+
+class CachedRoutes {
+  final List<RouteEntity> routes;
+  final int timestamp; // milliseconds since epoch
+
+  CachedRoutes({
+    required this.routes,
+    required this.timestamp,
+  });
+
+  bool isExpired() {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    const sevenDaysInMs = 7 * 24 * 60 * 60 * 1000;
+    return (now - timestamp) > sevenDaysInMs;
+  }
+}

--- a/lib/features/climbing_data/data/datasources/route_local_data_source.dart
+++ b/lib/features/climbing_data/data/datasources/route_local_data_source.dart
@@ -1,0 +1,46 @@
+import 'package:hive/hive.dart';
+import 'package:injectable/injectable.dart';
+import 'package:rockmate/core/domain/entities/route_entity.dart';
+import 'package:rockmate/core/data/models/cached_routes.dart';
+
+@injectable
+class RouteLocalDataSource {
+  static const String _boxName = 'route_cache';
+  Box<CachedRoutes>? _box;
+
+  Future<void> init() async {
+    if (_box == null || !_box!.isOpen) {
+      _box = await Hive.openBox<CachedRoutes>(_boxName);
+    }
+  }
+
+  Future<List<RouteEntity>?> getCachedRoutes(String query) async {
+    await init();
+    final cached = _box!.get(query);
+    
+    if (cached == null) {
+      return null;
+    }
+    
+    if (cached.isExpired()) {
+      await _box!.delete(query);
+      return null;
+    }
+    
+    return cached.routes;
+  }
+
+  Future<void> cacheRoutes(String query, List<RouteEntity> routes) async {
+    await init();
+    final cached = CachedRoutes(
+      routes: routes,
+      timestamp: DateTime.now().millisecondsSinceEpoch,
+    );
+    await _box!.put(query, cached);
+  }
+
+  Future<void> clearCache() async {
+    await init();
+    await _box!.clear();
+  }
+}

--- a/lib/injection.config.dart
+++ b/lib/injection.config.dart
@@ -12,13 +12,17 @@
 import 'package:get_it/get_it.dart' as _i174;
 import 'package:injectable/injectable.dart' as _i526;
 
+import 'features/climbing_data/data/datasources/route_local_data_source.dart'
+    as _i125;
+
 extension GetItInjectableX on _i174.GetIt {
   // initializes the registration of main-scope dependencies inside of GetIt
   _i174.GetIt init({
     String? environment,
     _i526.EnvironmentFilter? environmentFilter,
   }) {
-    _i526.GetItHelper(this, environment, environmentFilter);
+    final gh = _i526.GetItHelper(this, environment, environmentFilter);
+    gh.factory<_i125.RouteLocalDataSource>(() => _i125.RouteLocalDataSource());
     return this;
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,9 +3,15 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:beamer/beamer.dart';
 import 'injection.dart';
 import 'features/navigation/presentation/main_location.dart';
+import 'core/data/adapters/route_entity_adapter.dart';
+import 'core/data/adapters/cached_routes_adapter.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  
+  // Register Hive Adapters
+  Hive.registerAdapter(RouteEntityAdapter());
+  Hive.registerAdapter(CachedRoutesAdapter());
   
   // Initialize Hive
   await Hive.initFlutter();

--- a/test/features/climbing_data/data/datasources/route_local_data_source_test.dart
+++ b/test/features/climbing_data/data/datasources/route_local_data_source_test.dart
@@ -1,0 +1,107 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:rockmate/core/domain/entities/route_entity.dart';
+import 'package:rockmate/core/data/adapters/route_entity_adapter.dart';
+import 'package:rockmate/core/data/adapters/cached_routes_adapter.dart';
+import 'package:rockmate/core/data/models/cached_routes.dart';
+import 'package:rockmate/features/climbing_data/data/datasources/route_local_data_source.dart';
+
+void main() {
+  late RouteLocalDataSource dataSource;
+  late Directory tempDir;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('hive_test_');
+    Hive.init(tempDir.path);
+    Hive.registerAdapter(RouteEntityAdapter());
+    Hive.registerAdapter(CachedRoutesAdapter());
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    await tempDir.delete(recursive: true);
+  });
+
+  setUp(() {
+    dataSource = RouteLocalDataSource();
+  });
+
+  tearDown(() async {
+    await Hive.deleteBoxFromDisk('route_cache');
+  });
+
+  group('RouteLocalDataSource', () {
+    test('getCachedRoutes returns null when no cache exists', () async {
+      final result = await dataSource.getCachedRoutes('test_query');
+      expect(result, isNull);
+    });
+
+    test('cacheRoutes stores routes and getCachedRoutes retrieves them', () async {
+      final routes = [
+        const RouteEntity(
+          id: '1',
+          name: 'Test Route',
+          grade: '5.10a',
+          type: 'Sport',
+          rating: 4.5,
+          location: 'Test Area',
+        ),
+      ];
+
+      await dataSource.cacheRoutes('test_query', routes);
+      final result = await dataSource.getCachedRoutes('test_query');
+
+      expect(result, isNotNull);
+      expect(result!.length, 1);
+      expect(result.first.name, 'Test Route');
+    });
+
+    test('getCachedRoutes returns null for expired cache', () async {
+      final routes = [
+        const RouteEntity(
+          id: '1',
+          name: 'Test Route',
+          grade: '5.10a',
+          type: 'Sport',
+          rating: 4.5,
+          location: 'Test Area',
+        ),
+      ];
+
+      // Manually create an expired cache entry
+      await dataSource.init();
+      final box = await Hive.openBox<CachedRoutes>('route_cache');
+      final expiredTimestamp = DateTime.now().millisecondsSinceEpoch - (8 * 24 * 60 * 60 * 1000); // 8 days ago
+      final cached = CachedRoutes(routes: routes, timestamp: expiredTimestamp);
+      await box.put('test_query', cached);
+
+      final result = await dataSource.getCachedRoutes('test_query');
+      expect(result, isNull);
+    });
+
+    test('clearCache removes all cached data', () async {
+      final routes = [
+        const RouteEntity(
+          id: '1',
+          name: 'Test Route',
+          grade: '5.10a',
+          type: 'Sport',
+          rating: 4.5,
+          location: 'Test Area',
+        ),
+      ];
+
+      await dataSource.cacheRoutes('query1', routes);
+      await dataSource.cacheRoutes('query2', routes);
+      
+      await dataSource.clearCache();
+      
+      final result1 = await dataSource.getCachedRoutes('query1');
+      final result2 = await dataSource.getCachedRoutes('query2');
+      
+      expect(result1, isNull);
+      expect(result2, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Implements local caching layer for route search results using Hive with 7-day TTL.

## Changes
- Created `RouteEntityAdapter` for Hive binary serialization
- Created `CachedRoutesAdapter` (manual implementation to avoid dependency conflicts)
- Implemented `RouteLocalDataSource` with:
  - `getCachedRoutes(query)`: Retrieves cached routes, returns null if expired/missing
  - `cacheRoutes(query, routes)`: Stores routes with timestamp
  - `clearCache()`: Clears all cached data
- Created `CachedRoutes` model with `isExpired()` method for 7-day TTL
- Registered adapters in `main.dart`
- Added comprehensive unit tests covering caching, retrieval, expiration, and clearing

## Implementation Details
- Manual Hive adapters to avoid `freezed`/`hive_generator` dependency conflict
- TTL: 7 days (604,800,000 milliseconds)
- Injectable with `@injectable` for DI
- Lazy box initialization in `init()` method

## Testing
- ✅ All unit tests passing (4/4)
- Tests use `Hive.init()` with temp directory for isolation
- Coverage: cache miss, cache hit, expiration, and clearing

Closes #8