### PR TITLE
feat: implement first-launch download from GitHub Releases (Task 3-4/8)

### DIFF
--- a/lib/core/presentation/screens/data_download_screen.dart
+++ b/lib/core/presentation/screens/data_download_screen.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+import 'package:rockmate/core/services/climb_data_downloader.dart';
+import 'package:climb_data/climb_data.dart';
+
+class DataDownloadScreen extends StatefulWidget {
+  final VoidCallback onComplete;
+
+  const DataDownloadScreen({
+    Key? key,
+    required this.onComplete,
+  }) : super(key: key);
+
+  @override
+  State<DataDownloadScreen> createState() => _DataDownloadScreenState();
+}
+
+class _DataDownloadScreenState extends State<DataDownloadScreen> {
+  double _progress = 0.0;
+  String _status = 'Initializing...';
+  bool _hasError = false;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _startDownload();
+  }
+
+  Future<void> _startDownload() async {
+    try {
+      final dataSource = ClimbLocalDataSource();
+      final repository = ClimbRepository(dataSource);
+      final downloader = ClimbDataDownloader(repository);
+
+      await downloader.downloadAndImport(
+        onProgress: (progress, status) {
+          setState(() {
+            _progress = progress;
+            _status = status;
+          });
+        },
+      );
+
+      // Wait a moment to show completion
+      await Future.delayed(const Duration(seconds: 1));
+      widget.onComplete();
+    } catch (e) {
+      setState(() {
+        _hasError = true;
+        _errorMessage = e.toString();
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              Color(0xFF1E3A8A), // Blue-900
+              Color(0xFF3B82F6), // Blue-500
+            ],
+          ),
+        ),
+        child: SafeArea(
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.all(32.0),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(
+                    Icons.terrain,
+                    size: 80,
+                    color: Colors.white,
+                  ),
+                  const SizedBox(height: 24),
+                  const Text(
+                    'Setting up RockMate',
+                    style: TextStyle(
+                      fontSize: 28,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    _hasError
+                        ? 'Download failed'
+                        : 'Downloading climbing database...',
+                    style: TextStyle(
+                      fontSize: 16,
+                      color: Colors.white.withValues(alpha: 0.9),
+                    ),
+                  ),
+                  const SizedBox(height: 48),
+                  if (!_hasError) ...[
+                    SizedBox(
+                      width: double.infinity,
+                      child: LinearProgressIndicator(
+                        value: _progress,
+                        backgroundColor: Colors.white.withValues(alpha: 0.3),
+                        valueColor: const AlwaysStoppedAnimation<Color>(
+                          Colors.white,
+                        ),
+                        minHeight: 8,
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      _status,
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: Colors.white.withValues(alpha: 0.8),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      '${(_progress * 100).toStringAsFixed(0)}%',
+                      style: const TextStyle(
+                        fontSize: 48,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.white,
+                      ),
+                    ),
+                  ] else ...[
+                    Icon(
+                      Icons.error_outline,
+                      size: 64,
+                      color: Colors.red.shade300,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      _errorMessage ?? 'Unknown error occurred',
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        color: Colors.white,
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+                    ElevatedButton(
+                      onPressed: () {
+                        setState(() {
+                          _hasError = false;
+                          _errorMessage = null;
+                          _progress = 0.0;
+                          _status = 'Initializing...';
+                        });
+                        _startDownload();
+                      },
+                      child: const Text('Retry'),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/core/services/climb_data_downloader.dart
+++ b/lib/core/services/climb_data_downloader.dart
@@ -1,0 +1,73 @@
+import 'dart:io';
+import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
+import 'package:climb_data/climb_data.dart';
+
+class ClimbDataDownloader {
+  static const String _githubReleaseUrl = 
+      'https://github.com/shuchenku/rockmate/releases/latest/download/all_climbs.json';
+  
+  final ClimbRepository _repository;
+
+  ClimbDataDownloader(this._repository);
+
+  /// Download climb data from GitHub Releases with progress tracking
+  Future<void> downloadAndImport({
+    required Function(double progress, String status) onProgress,
+  }) async {
+    try {
+      onProgress(0.0, 'Connecting to server...');
+
+      // Download file
+      final response = await http.get(Uri.parse(_githubReleaseUrl));
+      
+      if (response.statusCode != 200) {
+        throw Exception('Failed to download: HTTP ${response.statusCode}');
+      }
+
+      onProgress(0.3, 'Download complete. Processing data...');
+
+      // Save to temporary file
+      final tempDir = await getTemporaryDirectory();
+      final tempFile = File('${tempDir.path}/all_climbs.json');
+      await tempFile.writeAsBytes(response.bodyBytes);
+
+      onProgress(0.4, 'Importing ${response.bodyBytes.length ~/ 1024 ~/ 1024}MB of data...');
+
+      // Import using DataImporter
+      final dataSource = ClimbLocalDataSource();
+      await dataSource.init();
+      
+      final importer = DataImporter(dataSource);
+      
+      int lastReportedProgress = 0;
+      await importer.importFromFile(
+        tempFile.path,
+        onProgress: (current, total) {
+          // Report progress every 5%
+          final progressPercent = ((current / total) * 100).round();
+          if (progressPercent - lastReportedProgress >= 5) {
+            lastReportedProgress = progressPercent;
+            final importProgress = 0.4 + (0.6 * (current / total));
+            onProgress(
+              importProgress,
+              'Importing climbs: $current/$total ($progressPercent%)',
+            );
+          }
+        },
+      );
+
+      // Cleanup
+      await tempFile.delete();
+      
+      onProgress(1.0, 'Import complete!');
+    } catch (e) {
+      throw Exception('Download failed: $e');
+    }
+  }
+
+  /// Check if data already exists
+  Future<bool> hasData() async {
+    return _repository.hasData;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,8 @@ import 'injection.dart';
 import 'features/navigation/presentation/main_location.dart';
 import 'core/data/adapters/route_entity_adapter.dart';
 import 'core/data/adapters/cached_routes_adapter.dart';
+import 'package:climb_data/climb_data.dart';
+import 'core/presentation/screens/data_download_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -17,24 +19,85 @@ void main() async {
   await Hive.initFlutter();
   
   // Configure Dependency Injection
-  configureDependencies();
+  await configureDependencies();
   
-  runApp(MyApp());
+  runApp(const MyApp());
 }
 
-class MyApp extends StatelessWidget {
-  MyApp({super.key});
+class MyApp extends StatefulWidget {
+  const MyApp({super.key});
 
-  final routerDelegate = BeamerDelegate(
-    locationBuilder: BeamerLocationBuilder(
-      beamLocations: [
-        MainLocation(const RouteInformation(location: '/')),
-      ],
-    ),
-  );
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  bool _isLoading = true;
+  bool _needsDownload = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _checkDataStatus();
+  }
+
+  Future<void> _checkDataStatus() async {
+    try {
+      final dataSource = ClimbLocalDataSource();
+      await dataSource.init();
+      final hasData = dataSource.hasData;
+
+      setState(() {
+        _needsDownload = !hasData;
+        _isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        _needsDownload = true;
+        _isLoading = false;
+      });
+    }
+  }
+
+  void _onDownloadComplete() {
+    setState(() {
+      _needsDownload = false;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
+    if (_isLoading) {
+      return const MaterialApp(
+        debugShowCheckedModeBanner: false,
+        home: Scaffold(
+          body: Center(
+            child: CircularProgressIndicator(),
+          ),
+        ),
+      );
+    }
+
+    if (_needsDownload) {
+      return MaterialApp(
+        debugShowCheckedModeBanner: false,
+        title: 'RockMate',
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.teal),
+          useMaterial3: true,
+        ),
+        home: DataDownloadScreen(onComplete: _onDownloadComplete),
+      );
+    }
+
+    final routerDelegate = BeamerDelegate(
+      locationBuilder: BeamerLocationBuilder(
+        beamLocations: [
+          MainLocation(const RouteInformation(uri: Uri(path: '/'))),
+        ],
+      ),
+    );
+
     return MaterialApp.router(
       debugShowCheckedModeBanner: false,
       title: 'RockMate',
@@ -47,4 +110,3 @@ class MyApp extends StatelessWidget {
     );
   }
 }
-

--- a/packages/climb_data/lib/src/data_importer.dart
+++ b/packages/climb_data/lib/src/data_importer.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 import 'package:flutter/services.dart' show rootBundle;
 import 'climb_local_data_source.dart';
 import 'models/climb_entity.dart';
@@ -13,7 +14,21 @@ class DataImporter {
       {Function(int current, int total)? onProgress}) async {
     // Load JSON from assets
     final jsonString = await rootBundle.loadString(assetPath);
-    
+    await _importFromString(jsonString, onProgress: onProgress);
+  }
+
+  /// Import climbs from downloaded file
+  Future<void> importFromFile(String filePath,
+      {Function(int current, int total)? onProgress}) async {
+    // Read JSON from file
+    final file = File(filePath);
+    final jsonString = await file.readAsString();
+    await _importFromString(jsonString, onProgress: onProgress);
+  }
+
+  /// Internal method to import from JSON string
+  Future<void> _importFromString(String jsonString,
+      {Function(int current, int total)? onProgress}) async {
     // Parse JSON Lines format (each line is a separate JSON object)
     final lines = LineSplitter.split(jsonString);
     final climbs = <ClimbEntity>[];

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -153,6 +153,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  climb_data:
+    dependency: "direct main"
+    description:
+      path: "packages/climb_data"
+      relative: true
+    source: path
+    version: "0.1.0"
   clock:
     dependency: transitive
     description:
@@ -353,7 +360,7 @@ packages:
     source: hosted
     version: "1.1.0"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
@@ -537,7 +544,7 @@ packages:
     source: hosted
     version: "1.9.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,8 +48,16 @@ dependencies:
   # Routing
   beamer: ^1.7.0
 
+  # HTTP & File System
+  http: ^1.2.0
+  path_provider: ^2.1.5
+
   # Utilities
   stream_transform: ^2.1.1
+  
+  # Internal packages
+  climb_data:
+    path: packages/climb_data
   
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Tasks 3-4: First-Launch Download from GitHub Releases

Skipped Task 3 (bundling 110MB in assets) per architect's design: Download from GitHub Releases on first launch instead.

### Components

**ClimbDataDownloader** (`lib/core/services/`)
- Downloads `all_climbs.json` from GitHub Releases
- Progress tracking with callbacks
- Error handling and retry logic

**DataDownloadScreen** (`lib/core/presentation/screens/`)
- Blue gradient background matching app theme
- Progress bar with percentage
- Status messages ("Connecting", "Processing", "Importing X/Y")
- Error UI with retry button

**Updated DataImporter** (`packages/climb_data/`)
- New `importFromFile()` method for downloaded files
- Refactored to use shared `_importFromString()` helper
- Maintains `importFromAsset()` for future use

### Integration

**main.dart** updated with:
1. Check if climb data exists on startup
2. Show loading spinner while checking
3. Show `DataDownloadScreen` if no data
4. Proceed to main app after download completes

### Dependencies Added
- `http: ^1.2.0` - HTTP downloads
- `path_provider: ^2.1.5` - Temp file storage
- `climb_data` package reference

### Next Steps
- Upload `all_climbs.json` to GitHub Releases manually
- Test Task 5-8: Update features to use climb_data

Part of migration: [x] Task 1-4 | [ ] Task 5-8