### PR TITLE
feat: Add data versioning and SyncMetadata persistence

### DIFF
--- a/lib/core/services/climb_data_downloader.dart
+++ b/lib/core/services/climb_data_downloader.dart
@@ -4,8 +4,11 @@ import 'package:path_provider/path_provider.dart';
 import 'package:climb_data/climb_data.dart';
 
 class ClimbDataDownloader {
+  /// Version of the climb data being downloaded
+  static const String dataVersion = 'v0.1.0-data';
+  
   static const String _githubReleaseUrl = 
-      'https://github.com/shuchenku/rockmate/releases/download/v0.1.0-data/all_climbs.json';
+      'https://github.com/shuchenku/rockmate/releases/download/$dataVersion/all_climbs.json';
   
   final ClimbRepository _repository;
 
@@ -56,6 +59,16 @@ class ClimbDataDownloader {
 
       // Cleanup
       await tempFile.delete();
+      
+      // Save version metadata
+      await _repository.dataSource.saveSyncMetadata(
+        SyncMetadata(
+          dataVersion: dataVersion,
+          lastSyncTimestamp: DateTime.now().millisecondsSinceEpoch,
+          downloadUrl: _githubReleaseUrl,
+          downloadSizeBytes: response.bodyBytes.length,
+        ),
+      );
       
       onProgress(1.0, 'Import complete!');
     } catch (e) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,9 +12,10 @@ void main() async {
   // Initialize Hive
   await Hive.initFlutter();
 
-  // Register ClimbEntityAdapter - catch if already registered
+  // Register Hive adapters - catch if already registered
   try {
     Hive.registerAdapter(ClimbEntityAdapter());
+    Hive.registerAdapter(SyncMetadataAdapter());
   } catch (e) {
     // Already registered, ignore
   }

--- a/packages/climb_data/lib/climb_data.dart
+++ b/packages/climb_data/lib/climb_data.dart
@@ -1,4 +1,5 @@
 export 'src/models/climb_entity.dart';
+export 'src/models/sync_metadata.dart';
 export 'src/climb_local_data_source.dart';
 export 'src/climb_repository.dart';
 export 'src/data_importer.dart';

--- a/packages/climb_data/lib/src/climb_local_data_source.dart
+++ b/packages/climb_data/lib/src/climb_local_data_source.dart
@@ -1,9 +1,14 @@
 import 'package:hive/hive.dart';
 import 'models/climb_entity.dart';
+import 'models/sync_metadata.dart';
 
 class ClimbLocalDataSource {
   static const String _boxName = 'climbs';
+  static const String _metadataBoxName = 'syncMetadata';
+  static const String _metadataKey = 'metadata';
+  
   Box<ClimbEntity>? _box;
+  Box<SyncMetadata>? _metadataBox;
 
   /// Initialize Hive and open climbs box
   Future<void> init() async {
@@ -184,6 +189,22 @@ class ClimbLocalDataSource {
   /// Check if data exists
   bool get hasData {
     return climbCount > 0;
+  }
+
+  /// Save sync metadata
+  Future<void> saveSyncMetadata(SyncMetadata metadata) async {
+    if (_metadataBox == null || !_metadataBox!.isOpen) {
+      _metadataBox = await Hive.openBox<SyncMetadata>(_metadataBoxName);
+    }
+    await _metadataBox!.put(_metadataKey, metadata);
+  }
+
+  /// Get sync metadata
+  Future<SyncMetadata?> getSyncMetadata() async {
+    if (_metadataBox == null || !_metadataBox!.isOpen) {
+      _metadataBox = await Hive.openBox<SyncMetadata>(_metadataBoxName);
+    }
+    return _metadataBox!.get(_metadataKey);
   }
 
   /// Close the box

--- a/packages/climb_data/lib/src/models/sync_metadata.dart
+++ b/packages/climb_data/lib/src/models/sync_metadata.dart
@@ -1,0 +1,38 @@
+import 'package:hive/hive.dart';
+
+part 'sync_metadata.g.dart';
+
+/// Tracks version and sync status of downloaded climb data
+@HiveType(typeId: 3)
+class SyncMetadata extends HiveObject {
+  /// Version tag of the data (e.g., 'v0.1.0-data')
+  @HiveField(0)
+  final String dataVersion;
+
+  /// Timestamp when data was last synced (milliseconds since epoch)
+  @HiveField(1)
+  final int lastSyncTimestamp;
+
+  /// URL from which the data was downloaded
+  @HiveField(2)
+  final String downloadUrl;
+
+  /// Size of the downloaded data in bytes
+  @HiveField(3)
+  final int downloadSizeBytes;
+
+  SyncMetadata({
+    required this.dataVersion,
+    required this.lastSyncTimestamp,
+    required this.downloadUrl,
+    required this.downloadSizeBytes,
+  });
+
+  /// DateTime of last sync
+  DateTime get lastSyncDate =>
+      DateTime.fromMillisecondsSinceEpoch(lastSyncTimestamp);
+
+  /// Human-readable size
+  String get downloadSizeMB =>
+      '${(downloadSizeBytes / 1024 / 1024).toStringAsFixed(1)} MB';
+}

--- a/packages/climb_data/lib/src/models/sync_metadata.g.dart
+++ b/packages/climb_data/lib/src/models/sync_metadata.g.dart
@@ -1,0 +1,50 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'sync_metadata.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class SyncMetadataAdapter extends TypeAdapter<SyncMetadata> {
+  @override
+  final int typeId = 3;
+
+  @override
+  SyncMetadata read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return SyncMetadata(
+      dataVersion: fields[0] as String,
+      lastSyncTimestamp: fields[1] as int,
+      downloadUrl: fields[2] as String,
+      downloadSizeBytes: fields[3] as int,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, SyncMetadata obj) {
+    writer
+      ..writeByte(4)
+      ..writeByte(0)
+      ..write(obj.dataVersion)
+      ..writeByte(1)
+      ..write(obj.lastSyncTimestamp)
+      ..writeByte(2)
+      ..write(obj.downloadUrl)
+      ..writeByte(3)
+      ..write(obj.downloadSizeBytes);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SyncMetadataAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -499,10 +499,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -776,26 +776,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
Implements Issue #36 - Data versioning and SyncMetadata persistence to track downloaded climb data versions.

## Changes

### New Files
- `packages/climb_data/lib/src/models/sync_metadata.dart` - Model for tracking version info
- `packages/climb_data/lib/src/models/sync_metadata.g.dart` - Generated Hive adapter

### Modified Files
- `packages/climb_data/lib/src/climb_local_data_source.dart` - Added `saveSyncMetadata()` and `getSyncMetadata()` methods
- `packages/climb_data/lib/climb_data.dart` - Export SyncMetadata model
- `lib/core/services/climb_data_downloader.dart` - Save version metadata after successful download
- `lib/main.dart` - Register SyncMetadataAdapter

## Features
- **SyncMetadata Model** (Hive typeId: 3)
  - `dataVersion` - Version tag (e.g., `v0.1.0-data`)
  - `lastSyncTimestamp` - When data was last synced
  - `downloadUrl` - Source URL
  - `downloadSizeBytes` - Download size
- **Helper methods**: `lastSyncDate`, `downloadSizeMB`
- Automatic version saving after successful data import

## Benefits
✅ Enables future background update checks  
✅ Better debugging when users report issues  
✅ Foundation for gradual data rollouts  
✅ Avoids unnecessary re-downloads

## Testing
- ✅ Flutter analyze passes
- ✅ Build_runner generated adapter successfully
- Manual testing: Delete app data → download → verify metadata saved

## Breaking Changes
None for new  users. Existing users will need to re-download data (~20MB) on first update to initialize version tracking.

Closes #36